### PR TITLE
Add docker compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  backend:
+    image: python:3.11-slim
+    working_dir: /app
+    command: >-
+      sh -c "pip install --no-cache-dir -r requirements.txt &&
+      uvicorn server:app --host 0.0.0.0 --port 8000 --reload"
+    volumes:
+      - ./backend:/app
+    environment:
+      CHATKIT_API_BASE: ${CHATKIT_API_BASE:-https://api.openai.com}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      CHATKIT_WORKFLOW_ID: ${CHATKIT_WORKFLOW_ID:-}
+    ports:
+      - "8000:8000"
+  frontend:
+    image: node:20
+    working_dir: /app
+    command: >-
+      sh -c "npm install && npm run dev -- --host 0.0.0.0 --port ${VITE_PORT:-5183}"
+    volumes:
+      - ./frontend:/app
+      - frontend-node_modules:/app/node_modules
+    environment:
+      VITE_BACKEND_URL: http://backend:8000
+      VITE_PORT: ${VITE_PORT:-5183}
+      VITE_HMR_HOST: ${VITE_HMR_HOST:-localhost}
+      VITE_HMR_CLIENT_PORT: ${VITE_HMR_CLIENT_PORT:-5183}
+      VITE_HMR_PROTOCOL: ${VITE_HMR_PROTOCOL:-ws}
+    ports:
+      - "${VITE_PORT:-5183}:${VITE_PORT:-5183}"
+    depends_on:
+      - backend
+volumes:
+  frontend-node_modules:

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,19 +1,31 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const parsePort = (value: string | undefined, fallback: number) => {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const serverPort = parsePort(process.env.VITE_PORT, 5183);
+const hmrClientPort = parsePort(process.env.VITE_HMR_CLIENT_PORT, 443);
+const hmrHost = process.env.VITE_HMR_HOST ?? "test.ve2fpd.com";
+const hmrProtocol = process.env.VITE_HMR_PROTOCOL ?? "wss";
+const backendTarget =
+  process.env.VITE_BACKEND_URL ?? "http://127.0.0.1:8000";
+
 export default defineConfig({
   server: {
-    host: true,            // écoute sur 0.0.0.0
-    port: 5183,            // fixe le port
-    strictPort: true,      // empêche vite de changer de port
+    host: true, // écoute sur 0.0.0.0
+    port: serverPort, // fixe le port
+    strictPort: true, // empêche vite de changer de port
     hmr: {
-      clientPort: 443,     // important derrière Cloudflare
-      host: "test.ve2fpd.com",
-      protocol: "wss",
+      clientPort: hmrClientPort, // important derrière Cloudflare
+      host: hmrHost,
+      protocol: hmrProtocol,
     },
     proxy: {
       "/api/chatkit/session": {
-        target: "http://127.0.0.1:8000",
+        target: backendTarget,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- add a docker-compose stack that runs the FastAPI backend and Vite frontend together
- configure the frontend dev server to read port, proxy and HMR settings from environment variables for container usage

## Testing
- Not run (Docker CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5acbf16f88322aad119be8171d2d4