### PR TITLE
docs: documenter le reverse proxy nginx

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Exemple de configuration pour le backend et le frontend ChatKit
+# Dupliquez ce fichier en `.env` (à la racine) et adaptez les valeurs.
+
+# --- Backend FastAPI ---
+# Clé API OpenAI disposant de l'accès ChatKit (obligatoire)
+OPENAI_API_KEY="sk-your-openai-api-key"
+
+# Identifiant du workflow ChatKit à utiliser (obligatoire)
+CHATKIT_WORKFLOW_ID="workflow-your-workflow-id"
+
+# URL de base de l'API OpenAI (optionnel)
+# CHATKIT_API_BASE="https://api.openai.com"
+
+# --- Frontend Vite ---
+# Port d'exposition du serveur Vite (optionnel)
+# VITE_PORT=5183
+
+# Hôte utilisé pour les connexions HMR (optionnel, utile derrière un tunnel/proxy)
+# VITE_HMR_HOST="localhost"
+# Exemple derrière Nginx : VITE_HMR_HOST="chatkit.example.com"
+
+# Protocole et port HMR à ajuster selon votre configuration réseau (optionnels)
+# VITE_HMR_PROTOCOL="ws"
+# VITE_HMR_CLIENT_PORT=5183
+# Exemple derrière Nginx : VITE_HMR_PROTOCOL="wss" et VITE_HMR_CLIENT_PORT=443
+
+# URL du backend à laquelle proxyfier les appels API depuis le frontend (optionnel)
+# VITE_BACKEND_URL="http://127.0.0.1:8000"
+# Exemple derrière Nginx : VITE_BACKEND_URL="https://chatkit.example.com/api"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Instructions pour les agents
+
+- Ce dépôt privilégie la rédaction de la documentation en français.
+- Lorsque vous ajoutez des commandes destinées aux utilisateurs, précisez depuis quel répertoire elles doivent être exécutées.
+- Si la configuration Docker évolue, mettez toujours à jour les sections correspondantes dans la documentation.
+
+## Rôle du code
+
+Le dépôt illustre une application de démonstration ChatKit composée d'un backend FastAPI (`backend/`) chargé de générer des secrets
+clients via l'API OpenAI et d'un frontend React/Vite (`frontend/`) qui embarque le widget ChatKit et dialogue avec le backend.
+L'objectif est de présenter rapidement un flux complet pour lancer un agent ChatKit depuis un navigateur.
+
+## Démarrage rapide (hors Docker)
+
+Toutes les commandes ci-dessous se lancent depuis la racine du dépôt.
+
+1. Préparez l'environnement Python du backend : `npm run backend:sync`.
+2. Démarrez le serveur FastAPI : `npm run backend:dev` (expose `http://localhost:8000`).
+3. Installez les dépendances du frontend : `npm run frontend:install`.
+4. Lancez le serveur Vite : `npm run frontend:dev` (expose `http://localhost:5173`).
+
+Le frontend proxyfie automatiquement les requêtes `/api/chatkit/session` vers le backend, ce qui permet de tester l'intégration
+ChatKit en quelques minutes.

--- a/README.md
+++ b/README.md
@@ -35,3 +35,70 @@ The `/api/chatkit/session` route makes an HTTP request to `https://api.openai.co
 - If `npm` complains about cache permissions, this repo ships with a local `.npmrc` pointing the cache to `.npm-cache/`; leave it in place or run `npm install --cache .npm-cache`
 
 With both servers running (`uv run uvicorn server:app --reload` in `backend/` and `npm run dev` inside `frontend/`), navigating to the Vite dev URL displays the embedded ChatKit widget backed by your Agent Builder workflow.
+
+## Lancement via Docker Compose
+
+Depuis la racine du dépôt, vous pouvez orchestrer le backend FastAPI et le frontend Vite via Docker Compose :
+
+1. Créez un fichier `.env` à la racine (au même niveau que `docker-compose.yml`) en vous basant sur `.env.example` et renseignez au minimum :
+   ```env
+   OPENAI_API_KEY="sk-..."
+   CHATKIT_WORKFLOW_ID="wf_..."
+   # Optionnel : ajustez le port d'exposition du frontend
+   VITE_PORT=5183
+   # Optionnel : ajustez le hostname utilisé par le HMR (utile derrière un tunnel/proxy)
+   VITE_HMR_HOST=localhost
+   ```
+   Les autres variables d'environnement exposées dans `docker-compose.yml` disposent de valeurs par défaut (`VITE_HMR_PROTOCOL`, `VITE_HMR_CLIENT_PORT`, `VITE_BACKEND_URL`, etc.) que vous pouvez également surcharger dans `.env` si nécessaire.
+2. Depuis la racine du projet, lancez `docker compose up` pour démarrer les deux services. Le backend répond sur `http://localhost:8000` et le frontend sur `http://localhost:${VITE_PORT}`.
+3. Utilisez `docker compose down` pour arrêter l'environnement de développement, puis relancez `docker compose up --build` si vous modifiez les dépendances système.
+
+Les volumes montés vous permettent de modifier le code localement tout en profitant du rafraîchissement à chaud côté frontend (`npm run dev -- --host 0.0.0.0`) et du rechargement automatique d'Uvicorn.
+
+### Exemple derrière un reverse proxy Nginx
+
+Si vous exposez l'environnement de développement via Nginx (par exemple sur `https://chatkit.example.com`), configurez d'abord `.env` à la racine :
+
+- `VITE_BACKEND_URL="https://chatkit.example.com/api"` pour forcer le frontend à appeler le backend via le reverse proxy.
+- `VITE_HMR_HOST="chatkit.example.com"`, `VITE_HMR_PROTOCOL="wss"` et `VITE_HMR_CLIENT_PORT=443` afin que le hot reload Vite continue de fonctionner à travers le proxy.
+
+Ensuite, adaptez votre bloc `server` Nginx (fichier `sites-available/chatkit.conf`, à activer via `ln -s` depuis `/etc/nginx/sites-enabled/`) :
+
+```nginx
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
+server {
+  listen 80;
+  listen 443 ssl;
+  server_name chatkit.example.com;
+
+  # Certificats TLS gérés via certbot/letsencrypt, à ajuster selon votre stack
+  ssl_certificate     /etc/letsencrypt/live/chatkit.example.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/chatkit.example.com/privkey.pem;
+
+  location /api/ {
+    proxy_pass http://127.0.0.1:8000/api/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+  }
+
+  location / {
+    proxy_pass http://127.0.0.1:5173/; # Ajustez le port si vous avez changé VITE_PORT
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+  }
+}
+```
+
+Redémarrez ensuite Nginx (`sudo systemctl reload nginx`) et relancez `docker compose up` depuis la racine si nécessaire. Le proxy transférera les requêtes HTTP classiques sur `/` vers Vite et les appels API `/api/…` vers FastAPI, tout en préservant les websockets nécessaires au HMR.


### PR DESCRIPTION
## Summary
- détailler dans le README une configuration type Nginx pour exposer le frontend Vite et le backend FastAPI via un reverse proxy
- compléter `.env.example` avec des valeurs indicatives à utiliser lorsque l’application est derrière Nginx

## Testing
- not run (documentation uniquement)


------
https://chatgpt.com/codex/tasks/task_e_68e5b0fc59848322bd23212bfa866cd0