### PR TITLE
Allow configuring Vite allowed hosts via env variable

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,9 @@ const hmrHost = process.env.VITE_HMR_HOST ?? "test.ve2fpd.com";
 const hmrProtocol = process.env.VITE_HMR_PROTOCOL ?? "wss";
 const backendTarget =
   process.env.VITE_BACKEND_URL ?? "http://127.0.0.1:8000";
+const allowedHosts = process.env.VITE_ALLOWED_HOSTS?.split(",")
+  .map((host) => host.trim())
+  .filter((host) => host.length > 0);
 
 export default defineConfig({
   server: {
@@ -23,6 +26,7 @@ export default defineConfig({
       host: hmrHost,
       protocol: hmrProtocol,
     },
+    ...(allowedHosts?.length ? { allowedHosts } : {}),
     proxy: {
       "/api/chatkit/session": {
         target: backendTarget,


### PR DESCRIPTION
## Summary
- add support for configuring Vite's allowedHosts list via the VITE_ALLOWED_HOSTS environment variable
- keep default behaviour when no additional host is provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5b9da258c83228274106d5e0fac25