### PR TITLE
Add chatkit.ve2fpd.com to Vite allowed hosts

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,9 +12,13 @@ const hmrHost = process.env.VITE_HMR_HOST ?? "test.ve2fpd.com";
 const hmrProtocol = process.env.VITE_HMR_PROTOCOL ?? "wss";
 const backendTarget =
   process.env.VITE_BACKEND_URL ?? "http://127.0.0.1:8000";
-const allowedHosts = process.env.VITE_ALLOWED_HOSTS?.split(",")
+const defaultAllowedHosts = ["chatkit.ve2fpd.com"];
+const envAllowedHosts = process.env.VITE_ALLOWED_HOSTS?.split(",")
   .map((host) => host.trim())
   .filter((host) => host.length > 0);
+const allowedHosts = envAllowedHosts?.length
+  ? Array.from(new Set([...envAllowedHosts, ...defaultAllowedHosts]))
+  : defaultAllowedHosts;
 
 export default defineConfig({
   server: {


### PR DESCRIPTION
## Summary
- include chatkit.ve2fpd.com in the default allowed hosts for the Vite dev server
- merge any hosts from VITE_ALLOWED_HOSTS with the default list to avoid duplicates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5bbe8c05c8322807147fa155c85e5