### PR TITLE
Sécuriser l'accueil ChatKit et fiabiliser la connexion

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,16 @@ const RequireAdmin = ({ children }: { children: ReactElement }) => {
   return children;
 };
 
+const RequireAuth = ({ children }: { children: ReactElement }) => {
+  const { user } = useAuth();
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};
+
 const RequireGuest = ({ children }: { children: ReactElement }) => {
   const { user } = useAuth();
 
@@ -32,6 +42,10 @@ const RequireGuest = ({ children }: { children: ReactElement }) => {
 
 const HomePage = () => {
   const { user, logout } = useAuth();
+
+  if (!user) {
+    return null;
+  }
 
   return (
     <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
@@ -47,22 +61,11 @@ const HomePage = () => {
       >
         <div>
           <strong>ChatKit Demo</strong>
-          {user ? (
-            <span style={{ marginLeft: "8px", color: "#475569" }}>
-              Connecté en tant que {user.email}
-            </span>
-          ) : (
-            <span style={{ marginLeft: "8px", color: "#475569" }}>
-              Session invitée
-            </span>
-          )}
+          <span style={{ marginLeft: "8px", color: "#475569" }}>
+            Connecté en tant que {user.email}
+          </span>
         </div>
         <div style={{ display: "flex", gap: "8px" }}>
-          {!user && (
-            <Link to="/login" style={{ color: "#2563eb", textDecoration: "none" }}>
-              Connexion
-            </Link>
-          )}
           {user?.is_admin && (
             <Link to="/admin" style={{ color: "#2563eb", textDecoration: "none" }}>
               Administration
@@ -95,7 +98,14 @@ const HomePage = () => {
 
 export const App = () => (
   <Routes>
-    <Route path="/" element={<HomePage />} />
+    <Route
+      path="/"
+      element={(
+        <RequireAuth>
+          <HomePage />
+        </RequireAuth>
+      )}
+    />
     <Route
       path="/login"
       element={


### PR DESCRIPTION
## Summary
- rediriger les utilisateurs non authentifiés vers `/login` avant d'afficher le widget ChatKit et ajuster l'interface d'accueil
- fiabiliser l'appel de connexion côté frontend en tentant `/api/auth/login` puis `VITE_BACKEND_URL` pour éviter les erreurs « Failed to fetch »
- documenter ces changements dans le README

## Testing
- npm install --prefix frontend
- npm run --prefix frontend build

------
https://chatgpt.com/codex/tasks/task_e_68e5c34f2fa083228ffb0b69e578b1d8