### PR TITLE
Refonte visuelle responsive du frontend

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,50 +48,29 @@ const HomePage = () => {
   }
 
   return (
-    <div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
-      <header
-        style={{
-          padding: "12px 16px",
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          borderBottom: "1px solid #e2e8f0",
-          backgroundColor: "#f8fafc",
-        }}
-      >
-        <div>
-          <strong>ChatKit Demo</strong>
-          <span style={{ marginLeft: "8px", color: "#475569" }}>
-            Connecté en tant que {user.email}
-          </span>
-        </div>
-        <div style={{ display: "flex", gap: "8px" }}>
-          {user?.is_admin && (
-            <Link to="/admin" style={{ color: "#2563eb", textDecoration: "none" }}>
-              Administration
-            </Link>
-          )}
-          {user && (
-            <button
-              type="button"
-              onClick={logout}
-              style={{
-                backgroundColor: "#dc2626",
-                color: "white",
-                border: "none",
-                borderRadius: "4px",
-                padding: "6px 12px",
-                cursor: "pointer",
-              }}
-            >
+    <div className="app-shell">
+      <header className="app-shell__header">
+        <div className="app-shell__header-inner">
+          <div className="branding">
+            <h1 className="branding__title">ChatKit Demo</h1>
+            <p className="branding__subtitle">Connecté en tant que {user.email}</p>
+          </div>
+          <div className="header-actions">
+            <span className="header-actions__pill">Session sécurisée</span>
+            {user?.is_admin && (
+              <Link className="button button--ghost" to="/admin">
+                Administration
+              </Link>
+            )}
+            <button className="button button--danger" type="button" onClick={logout}>
               Déconnexion
             </button>
-          )}
+          </div>
         </div>
       </header>
-      <div style={{ flex: "1 1 auto" }}>
+      <main className="app-shell__main">
         <MyChat />
-      </div>
+      </main>
     </div>
   );
 };

--- a/frontend/src/MyChat.tsx
+++ b/frontend/src/MyChat.tsx
@@ -122,69 +122,30 @@ export function MyChat() {
 
   const { control } = useChatKit(chatkitOptions);
 
+  const statusMessage = error
+    ? error
+    : isLoading
+      ? "Initialisation de la session…"
+      : "Votre assistant est prêt à répondre.";
+
+  const statusClassName = [
+    "status-banner",
+    error ? "status-banner--error" : "",
+    !error && isLoading ? "status-banner--loading" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <div
-      style={{
-        minHeight: "100dvh",
-        backgroundColor: "#f8fafc",
-        paddingTop: "calc(16px + env(safe-area-inset-top, 0px))",
-        paddingBottom: "calc(16px + env(safe-area-inset-bottom, 0px))",
-        paddingLeft: "calc(16px + env(safe-area-inset-left, 0px))",
-        paddingRight: "calc(16px + env(safe-area-inset-right, 0px))",
-        boxSizing: "border-box",
-      }}
-    >
-      <div
-        style={{
-          margin: "0 auto",
-          maxWidth: "960px",
-          width: "100%",
-          minHeight:
-            "calc(100dvh - 32px - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px))",
-          display: "flex",
-          flexDirection: "column",
-          gap: "12px",
-          paddingLeft: "clamp(8px, 4vw, 16px)",
-          paddingRight: "clamp(8px, 4vw, 16px)",
-          boxSizing: "border-box",
-        }}
-      >
-        <div
-          style={{
-            flex: "1 1 auto",
-            minHeight: "0",
-            borderRadius: "18px",
-            overflow: "hidden",
-            boxShadow: "0 12px 30px rgba(15, 23, 42, 0.12)",
-            backgroundColor: "#ffffff",
-            display: "flex",
-          }}
-        >
-          <ChatKit
-            control={control}
-            style={{
-              flex: "1 1 auto",
-              width: "100%",
-              height: "100%",
-              minHeight: "clamp(260px, calc(100dvh - 160px), 720px)",
-            }}
-          />
-        </div>
-        <div
-          style={{
-            padding: "10px 18px",
-            fontSize: "0.9rem",
-            color: error ? "#dc2626" : "#475569",
-            backgroundColor: "#ffffffcc",
-            border: "1px solid #e2e8f0",
-            borderRadius: "12px",
-            backdropFilter: "blur(4px)",
-            textAlign: "center",
-          }}
-        >
-          {error ? error : isLoading ? "Initialisation de la session…" : "\u00A0"}
-        </div>
+    <div className="app-shell__content">
+      <div className="chat-card">
+        <ChatKit
+          control={control}
+          className="chatkit-host"
+          style={{ width: "100%", height: "100%" }}
+        />
       </div>
+      <div className={statusClassName}>{statusMessage}</div>
     </div>
   );
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from "react-router-dom";
 
 import { App } from "./App";
 import { AuthProvider } from "./auth";
+import "./styles.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -62,7 +62,7 @@ export const AdminPage = () => {
     } finally {
       setLoading(false);
     }
-  }, [headers, token]);
+  }, [headers, logout, token]);
 
   useEffect(() => {
     void fetchUsers();
@@ -185,214 +185,148 @@ export const AdminPage = () => {
     }
   };
 
+  const userCountLabel = users.length
+    ? ` · ${users.length} utilisateur${users.length > 1 ? "s" : ""}`
+    : "";
+
   return (
-    <div style={{ minHeight: "100vh", backgroundColor: "#f8fafc" }}>
-      <header
-        style={{
-          padding: "16px 24px",
-          backgroundColor: "white",
-          borderBottom: "1px solid #e2e8f0",
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
-      >
-        <div>
-          <h1 style={{ margin: 0, fontSize: "1.75rem", color: "#0f172a" }}>Administration des utilisateurs</h1>
-          <p style={{ margin: "4px 0 0", color: "#475569" }}>
-            Gérez les comptes autorisés à accéder au widget ChatKit.
-          </p>
-        </div>
-        <div style={{ display: "flex", gap: "12px", alignItems: "center" }}>
-          <span style={{ color: "#475569" }}>{currentUser?.email}</span>
-          <button
-            type="button"
-            onClick={logout}
-            style={{
-              backgroundColor: "#0f172a",
-              color: "white",
-              border: "none",
-              borderRadius: "8px",
-              padding: "10px 14px",
-              cursor: "pointer",
-            }}
-          >
-            Déconnexion
-          </button>
-        </div>
-      </header>
-
-      <main style={{ padding: "24px", display: "flex", flexDirection: "column", gap: "24px" }}>
-        {error && (
-          <div style={{ color: "#b91c1c", backgroundColor: "#fee2e2", padding: "12px", borderRadius: "8px" }}>
-            {error}
+    <div className="admin-layout">
+      <div className="admin-shell">
+        <header className="admin-shell__header">
+          <div>
+            <h1 className="admin-shell__title">Administration des utilisateurs</h1>
+            <p className="admin-shell__subtitle">
+              Gérez les accès autorisés au widget ChatKit et pilotez les rôles en un clin d'œil.
+            </p>
           </div>
-        )}
-
-        <section
-          style={{
-            backgroundColor: "white",
-            borderRadius: "12px",
-            padding: "24px",
-            boxShadow: "0 10px 30px rgba(15, 23, 42, 0.05)",
-          }}
-        >
-          <h2 style={{ marginTop: 0, color: "#0f172a" }}>Créer un utilisateur</h2>
-          <form onSubmit={handleCreate} style={{ display: "flex", gap: "16px", flexWrap: "wrap" }}>
-            <label style={{ flex: "1 1 220px", display: "flex", flexDirection: "column", gap: "6px" }}>
-              E-mail
-              <input
-                type="email"
-                required
-                value={createPayload.email}
-                onChange={(event) => setCreatePayload((prev) => ({ ...prev, email: event.target.value }))}
-                placeholder="nouvel.utilisateur@example.com"
-                style={{
-                  padding: "10px 12px",
-                  borderRadius: "8px",
-                  border: "1px solid #cbd5f5",
-                }}
-              />
-            </label>
-            <label style={{ flex: "1 1 200px", display: "flex", flexDirection: "column", gap: "6px" }}>
-              Mot de passe
-              <input
-                type="text"
-                required
-                value={createPayload.password}
-                onChange={(event) => setCreatePayload((prev) => ({ ...prev, password: event.target.value }))}
-                placeholder="Mot de passe temporaire"
-                style={{
-                  padding: "10px 12px",
-                  borderRadius: "8px",
-                  border: "1px solid #cbd5f5",
-                }}
-              />
-            </label>
-            <label
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "8px",
-                paddingTop: "24px",
-              }}
-            >
-              <input
-                type="checkbox"
-                checked={createPayload.is_admin}
-                onChange={(event) =>
-                  setCreatePayload((prev) => ({ ...prev, is_admin: event.target.checked }))
-                }
-              />
-              Administrateur
-            </label>
-            <button
-              type="submit"
-              style={{
-                backgroundColor: "#2563eb",
-                color: "white",
-                border: "none",
-                borderRadius: "8px",
-                padding: "12px 20px",
-                cursor: "pointer",
-                alignSelf: "flex-end",
-              }}
-            >
-              Ajouter
+          <div className="admin-shell__toolbar">
+            <span className="admin-shell__chips">
+              {currentUser?.email ?? "Administrateur"}
+              {userCountLabel}
+            </span>
+            <button className="button button--ghost" type="button" onClick={logout}>
+              Déconnexion
             </button>
-          </form>
-        </section>
+          </div>
+        </header>
 
-        <section
-          style={{
-            backgroundColor: "white",
-            borderRadius: "12px",
-            padding: "24px",
-            boxShadow: "0 10px 30px rgba(15, 23, 42, 0.05)",
-          }}
-        >
-          <h2 style={{ marginTop: 0, color: "#0f172a" }}>Utilisateurs</h2>
-          {isLoading ? (
-            <p>Chargement des utilisateurs…</p>
-          ) : users.length === 0 ? (
-            <p>Aucun utilisateur pour le moment.</p>
-          ) : (
-            <div style={{ overflowX: "auto" }}>
-              <table style={{ width: "100%", borderCollapse: "collapse" }}>
-                <thead>
-                  <tr style={{ textAlign: "left", color: "#475569" }}>
-                    <th style={{ padding: "12px" }}>E-mail</th>
-                    <th style={{ padding: "12px" }}>Rôle</th>
-                    <th style={{ padding: "12px" }}>Créé le</th>
-                    <th style={{ padding: "12px" }}>Mis à jour le</th>
-                    <th style={{ padding: "12px" }}>Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {users.map((editableUser) => (
-                    <tr key={editableUser.id} style={{ borderTop: "1px solid #e2e8f0" }}>
-                      <td style={{ padding: "12px" }}>{editableUser.email}</td>
-                      <td style={{ padding: "12px" }}>
-                        {editableUser.is_admin ? "Administrateur" : "Utilisateur"}
-                      </td>
-                      <td style={{ padding: "12px" }}>
-                        {new Date(editableUser.created_at).toLocaleString()}
-                      </td>
-                      <td style={{ padding: "12px" }}>
-                        {new Date(editableUser.updated_at).toLocaleString()}
-                      </td>
-                      <td style={{ padding: "12px", display: "flex", gap: "8px" }}>
-                        <button
-                          type="button"
-                          onClick={() => handleToggleAdmin(editableUser)}
-                          style={{
-                            backgroundColor: "#1d4ed8",
-                            color: "white",
-                            border: "none",
-                            borderRadius: "6px",
-                            padding: "8px 12px",
-                            cursor: "pointer",
-                          }}
-                        >
-                          {editableUser.is_admin ? "Retirer admin" : "Promouvoir"}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleResetPassword(editableUser)}
-                          style={{
-                            backgroundColor: "#0f172a",
-                            color: "white",
-                            border: "none",
-                            borderRadius: "6px",
-                            padding: "8px 12px",
-                            cursor: "pointer",
-                          }}
-                        >
-                          Réinitialiser le mot de passe
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => handleDelete(editableUser)}
-                          style={{
-                            backgroundColor: "#dc2626",
-                            color: "white",
-                            border: "none",
-                            borderRadius: "6px",
-                            padding: "8px 12px",
-                            cursor: "pointer",
-                          }}
-                        >
-                          Supprimer
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+        {error && <div className="alert alert--danger">{error}</div>}
+
+        <div className="admin-grid">
+          <section className="admin-card">
+            <div>
+              <h2 className="admin-card__title">Créer un utilisateur</h2>
+              <p className="admin-card__subtitle">
+                Invitez un collaborateur et attribuez-lui un rôle adapté à son usage de ChatKit.
+              </p>
             </div>
-          )}
-        </section>
-      </main>
+            <form className="admin-form" onSubmit={handleCreate}>
+              <div className="admin-form__row">
+                <label className="label">
+                  E-mail
+                  <input
+                    className="input"
+                    type="email"
+                    required
+                    value={createPayload.email}
+                    onChange={(event) => setCreatePayload((prev) => ({ ...prev, email: event.target.value }))}
+                    placeholder="nouvel.utilisateur@example.com"
+                  />
+                </label>
+                <label className="label">
+                  Mot de passe temporaire
+                  <input
+                    className="input"
+                    type="text"
+                    required
+                    value={createPayload.password}
+                    onChange={(event) => setCreatePayload((prev) => ({ ...prev, password: event.target.value }))}
+                    placeholder="Mot de passe temporaire"
+                  />
+                </label>
+              </div>
+              <label className="checkbox-field">
+                <input
+                  type="checkbox"
+                  checked={createPayload.is_admin}
+                  onChange={(event) =>
+                    setCreatePayload((prev) => ({ ...prev, is_admin: event.target.checked }))
+                  }
+                />
+                Administrateur
+              </label>
+              <div className="admin-form__actions">
+                <button className="button" type="submit">
+                  Ajouter
+                </button>
+              </div>
+            </form>
+          </section>
+
+          <section className="admin-card">
+            <div>
+              <h2 className="admin-card__title">Utilisateurs</h2>
+              <p className="admin-card__subtitle">
+                Consultez les accès existants et appliquez des actions rapides pour chaque compte.
+              </p>
+            </div>
+            {isLoading ? (
+              <p className="admin-card__subtitle">Chargement des utilisateurs…</p>
+            ) : users.length === 0 ? (
+              <p className="admin-card__subtitle">Aucun utilisateur pour le moment.</p>
+            ) : (
+              <div className="admin-table-wrapper">
+                <table className="admin-table">
+                  <thead>
+                    <tr>
+                      <th>E-mail</th>
+                      <th>Rôle</th>
+                      <th>Créé le</th>
+                      <th>Mis à jour le</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {users.map((editableUser) => (
+                      <tr key={editableUser.id}>
+                        <td>{editableUser.email}</td>
+                        <td>{editableUser.is_admin ? "Administrateur" : "Utilisateur"}</td>
+                        <td>{new Date(editableUser.created_at).toLocaleString()}</td>
+                        <td>{new Date(editableUser.updated_at).toLocaleString()}</td>
+                        <td>
+                          <div className="admin-table__actions">
+                            <button
+                              className="button button--subtle button--sm"
+                              type="button"
+                              onClick={() => handleToggleAdmin(editableUser)}
+                            >
+                              {editableUser.is_admin ? "Retirer admin" : "Promouvoir"}
+                            </button>
+                            <button
+                              className="button button--ghost button--sm"
+                              type="button"
+                              onClick={() => handleResetPassword(editableUser)}
+                            >
+                              Réinitialiser
+                            </button>
+                            <button
+                              className="button button--danger button--sm"
+                              type="button"
+                              onClick={() => handleDelete(editableUser)}
+                            >
+                              Supprimer
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -87,91 +87,44 @@ export const LoginPage = () => {
   };
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundColor: "#f1f5f9",
-        padding: "24px",
-      }}
-    >
-      <form
-        onSubmit={handleSubmit}
-        style={{
-          width: "100%",
-          maxWidth: "400px",
-          backgroundColor: "white",
-          padding: "32px",
-          borderRadius: "12px",
-          boxShadow: "0 10px 30px rgba(15, 23, 42, 0.08)",
-          display: "flex",
-          flexDirection: "column",
-          gap: "16px",
-        }}
-      >
+    <div className="login-layout">
+      <form className="login-card" onSubmit={handleSubmit}>
         <div>
-          <h1 style={{ margin: 0, fontSize: "1.5rem", color: "#0f172a" }}>Connexion</h1>
-          <p style={{ margin: "8px 0 0", color: "#475569" }}>
-            Accédez au panneau d'administration pour gérer les utilisateurs.
+          <h1 className="login-card__title">Connexion</h1>
+          <p className="login-card__subtitle">
+            Accédez au panneau d'administration pour gérer les utilisateurs et vos sessions ChatKit.
           </p>
         </div>
 
-        <label style={{ display: "flex", flexDirection: "column", gap: "8px", color: "#1e293b" }}>
-          Adresse e-mail
-          <input
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.target.value)}
-            required
-            placeholder="vous@example.com"
-            style={{
-              padding: "10px 12px",
-              borderRadius: "8px",
-              border: "1px solid #cbd5f5",
-              fontSize: "1rem",
-            }}
-          />
-        </label>
+        <div className="form-grid">
+          <label className="label">
+            Adresse e-mail
+            <input
+              className="input"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              placeholder="vous@example.com"
+            />
+          </label>
 
-        <label style={{ display: "flex", flexDirection: "column", gap: "8px", color: "#1e293b" }}>
-          Mot de passe
-          <input
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.target.value)}
-            required
-            placeholder="••••••••"
-            style={{
-              padding: "10px 12px",
-              borderRadius: "8px",
-              border: "1px solid #cbd5f5",
-              fontSize: "1rem",
-            }}
-          />
-        </label>
+          <label className="label">
+            Mot de passe
+            <input
+              className="input"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              placeholder="••••••••"
+            />
+          </label>
+        </div>
 
-        {error && (
-          <div style={{ color: "#b91c1c", backgroundColor: "#fee2e2", padding: "12px", borderRadius: "8px" }}>
-            {error}
-          </div>
-        )}
+        {error && <div className="alert alert--danger">{error}</div>}
 
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          style={{
-            backgroundColor: isSubmitting ? "#94a3b8" : "#2563eb",
-            color: "white",
-            border: "none",
-            borderRadius: "8px",
-            padding: "12px 16px",
-            fontSize: "1rem",
-            cursor: isSubmitting ? "not-allowed" : "pointer",
-            transition: "background-color 0.2s ease",
-          }}
-        >
+        <button className="button" type="submit" disabled={isSubmitting}>
           {isSubmitting ? "Connexion en cours…" : "Se connecter"}
         </button>
       </form>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,519 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  --app-gradient: linear-gradient(160deg, #0f172a 0%, #1d4ed8 45%, #38bdf8 100%);
+  --surface-color: rgba(255, 255, 255, 0.92);
+  --surface-strong: #ffffff;
+  --surface-border: rgba(148, 163, 184, 0.35);
+  --text-color: #0f172a;
+  --text-muted: #475569;
+  --primary-color: #2563eb;
+  --primary-hover: #1d4ed8;
+  --danger-color: #dc2626;
+  --danger-hover: #b91c1c;
+  --shadow-soft: 0 20px 45px rgba(15, 23, 42, 0.18);
+  --shadow-card: 0 30px 60px rgba(15, 23, 42, 0.15);
+  --header-height: clamp(64px, 8vh, 80px);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--app-gradient);
+  color: var(--text-color);
+  display: flex;
+  justify-content: center;
+  padding: 0;
+}
+
+#root {
+  flex: 1;
+  min-height: 100vh;
+}
+
+a {
+  color: var(--primary-color);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--primary-hover);
+  text-decoration: underline;
+}
+
+button {
+  font-family: inherit;
+}
+
+.app-shell {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.app-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.22), transparent);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.app-shell__header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  height: var(--header-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 clamp(16px, 6vw, 48px);
+}
+
+.app-shell__header-inner {
+  width: min(1200px, 100%);
+  background: var(--surface-color);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--surface-border);
+  border-radius: 20px;
+  padding: 16px clamp(18px, 4vw, 28px);
+  display: flex;
+  align-items: center;
+  gap: clamp(12px, 3vw, 32px);
+  justify-content: space-between;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+}
+
+.branding {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.branding__title {
+  font-size: clamp(1.25rem, 2.4vw, 1.75rem);
+  font-weight: 700;
+  margin: 0;
+  color: var(--text-color);
+}
+
+.branding__subtitle {
+  color: var(--text-muted);
+  font-size: clamp(0.85rem, 2vw, 1rem);
+  margin: 0;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: clamp(10px, 2vw, 20px);
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.header-actions__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--primary-hover);
+  font-weight: 600;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 12px;
+  border: none;
+  padding: 10px 16px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  box-shadow: 0 12px 25px rgba(37, 99, 235, 0.35);
+  background: var(--primary-color);
+}
+
+.button:hover,
+.button:focus-visible {
+  background: var(--primary-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 15px 32px rgba(37, 99, 235, 0.35);
+}
+
+.button--sm {
+  padding: 8px 12px;
+  font-size: 0.85rem;
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.25);
+}
+
+.button--danger {
+  background: var(--danger-color);
+  box-shadow: 0 12px 25px rgba(220, 38, 38, 0.25);
+}
+
+.button--danger:hover,
+.button--danger:focus-visible {
+  background: var(--danger-hover);
+}
+
+.button--ghost {
+  background: rgba(15, 23, 42, 0.78);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.28);
+}
+
+.button--subtle {
+  background: rgba(15, 23, 42, 0.04);
+  color: var(--text-color);
+  box-shadow: none;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.button--subtle:hover,
+.button--subtle:focus-visible {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary-hover);
+}
+
+.button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+.app-shell__main {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: clamp(20px, 6vh, 48px) clamp(16px, 7vw, 64px) clamp(32px, 8vh, 80px);
+  position: relative;
+  z-index: 1;
+}
+
+.app-shell__content {
+  width: min(1100px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 3vh, 32px);
+}
+
+.chat-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-strong);
+  border-radius: clamp(18px, 3vw, 24px);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+  min-height: clamp(320px, 65dvh, 780px);
+}
+
+.chatkit-host {
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+}
+
+.status-banner {
+  align-self: center;
+  width: min(560px, 100%);
+  text-align: center;
+  border-radius: 18px;
+  padding: 14px 18px;
+  background: var(--surface-color);
+  border: 1px solid var(--surface-border);
+  backdrop-filter: blur(12px);
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.18);
+}
+
+.status-banner--error {
+  color: var(--danger-hover);
+  border-color: rgba(220, 38, 38, 0.3);
+  background: rgba(254, 226, 226, 0.85);
+}
+
+.status-banner--loading {
+  color: var(--primary-hover);
+}
+
+.login-layout,
+.admin-layout {
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(24px, 6vw, 48px);
+  position: relative;
+}
+
+.login-layout::before,
+.admin-layout::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 120% at 15% 15%, rgba(56, 189, 248, 0.55), transparent),
+    radial-gradient(120% 120% at 85% 30%, rgba(37, 99, 235, 0.35), transparent);
+  z-index: 0;
+}
+
+.login-card,
+.admin-shell {
+  position: relative;
+  z-index: 1;
+  width: min(480px, 100%);
+  background: var(--surface-strong);
+  border-radius: 28px;
+  padding: clamp(28px, 5vw, 40px);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 4vh, 28px);
+}
+
+.login-card__title,
+.admin-shell__title {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2rem);
+  font-weight: 700;
+}
+
+.login-card__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: clamp(0.95rem, 3vw, 1.05rem);
+}
+
+.admin-shell__subtitle {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.75);
+  font-size: clamp(1rem, 2.8vw, 1.1rem);
+}
+
+.form-grid {
+  display: grid;
+  gap: clamp(14px, 3vh, 20px);
+}
+
+.label {
+  display: grid;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.input {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background-color: rgba(255, 255, 255, 0.95);
+}
+
+.input:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+}
+
+.alert {
+  padding: 14px 16px;
+  border-radius: 12px;
+  font-size: 0.95rem;
+}
+
+.alert--danger {
+  background: rgba(254, 226, 226, 0.9);
+  color: var(--danger-hover);
+}
+
+.admin-shell {
+  width: min(1180px, 100%);
+  gap: clamp(24px, 5vh, 36px);
+}
+
+.admin-shell__header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.admin-shell__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.admin-shell__chips {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.admin-grid {
+  display: grid;
+  gap: clamp(18px, 4vh, 28px);
+}
+
+.admin-card {
+  background: var(--surface-strong);
+  border-radius: 24px;
+  padding: clamp(24px, 4vw, 32px);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  display: grid;
+  gap: clamp(18px, 3vh, 24px);
+}
+
+.admin-card__title {
+  margin: 0;
+  font-size: clamp(1.1rem, 2.6vw, 1.35rem);
+  color: var(--text-color);
+}
+
+.admin-card__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.admin-form {
+  display: grid;
+  gap: clamp(16px, 2vw, 24px);
+}
+
+.admin-form__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(14px, 2vw, 20px);
+}
+
+.admin-form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.checkbox-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  padding-top: 8px;
+}
+
+.checkbox-field input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--primary-color);
+}
+
+.admin-table-wrapper {
+  overflow: hidden;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(255, 255, 255, 0.96);
+}
+
+.admin-table thead {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--text-muted);
+}
+
+.admin-table th,
+.admin-table td {
+  padding: clamp(12px, 2vw, 18px);
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  font-size: 0.95rem;
+}
+
+.admin-table tbody tr:hover {
+  background: rgba(37, 99, 235, 0.05);
+}
+
+.admin-table__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 768px) {
+  .app-shell__header-inner {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 18px;
+  }
+
+  .header-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .app-shell__main {
+    padding: clamp(20px, 8vh, 48px) clamp(16px, 4vw, 32px) clamp(32px, 10vh, 72px);
+  }
+
+  .status-banner {
+    width: 100%;
+  }
+
+  .admin-shell__toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .admin-table__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (max-width: 520px) {
+  .app-shell__header-inner {
+    border-radius: 16px;
+  }
+
+  .chat-card {
+    border-radius: 18px;
+    min-height: clamp(360px, 70dvh, 720px);
+  }
+
+  .login-card,
+  .admin-shell {
+    border-radius: 22px;
+  }
+}


### PR DESCRIPTION
## Summary
- introduit une feuille de style globale moderne pour harmoniser les couleurs, la typographie et les composants
- retravaille les pages d’accueil, de connexion et d’administration pour un rendu premium sur mobile et desktop
- affine l’intégration du widget ChatKit avec un encart épuré et des messages d’état lisibles

## Testing
- npm run frontend:build  # depuis la racine du dépôt


------
https://chatgpt.com/codex/tasks/task_e_68e5cb85953c8322a37a857fa70364e9