### PR TITLE
Add configurable CORS support for admin requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ CHATKIT_WORKFLOW_ID="workflow-your-workflow-id"
 # URL de base de l'API OpenAI (optionnel)
 # CHATKIT_API_BASE="https://api.openai.com"
 
+# Origines autorisées pour les requêtes navigateur (optionnel, séparées par des virgules)
+# ALLOWED_ORIGINS="http://localhost:5173,https://chatkit.example.com"
+
 # --- Frontend Vite ---
 # Port d'exposition du serveur Vite (optionnel)
 # VITE_PORT=5183

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Les scripts utilisent `uv` et `npm` en ciblant les sous-dossiers, évitant ainsi
     environnement Docker Compose, utilisez le hostname du service PostgreSQL (`db`) plutôt que `localhost`, par exemple
     `postgresql+psycopg://chatkit:chatkit@db:5432/chatkit`.
   - `AUTH_SECRET_KEY` – clé secrète utilisée pour signer les tokens JWT
+  - Optionnel : `ALLOWED_ORIGINS` pour lister les origines autorisées par CORS (séparées par des virgules, par défaut `*`)
   - Optionnel : `ACCESS_TOKEN_EXPIRE_MINUTES` pour ajuster la durée de validité du token (par défaut 120 min)
   - Optionnel : `ADMIN_EMAIL` et `ADMIN_PASSWORD` pour provisionner automatiquement un compte administrateur au démarrage
   - Optionnel : `DATABASE_CONNECT_RETRIES` / `DATABASE_CONNECT_DELAY` pour ajuster la stratégie d'attente au démarrage

--- a/backend/server.py
+++ b/backend/server.py
@@ -11,6 +11,7 @@ import httpx
 import jwt
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException, Response, status
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, EmailStr
 from sqlalchemy import Boolean, DateTime, Integer, String, create_engine, select, text
@@ -64,6 +65,21 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("chatkit.server")
 
 app = FastAPI()
+
+_allowed_origins_raw = os.environ.get("ALLOWED_ORIGINS")
+if _allowed_origins_raw:
+    _allowed_origins = [origin.strip() for origin in _allowed_origins_raw.split(",") if origin.strip()]
+    if not _allowed_origins:
+        _allowed_origins = ["*"]
+else:
+    _allowed_origins = ["*"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=_allowed_origins,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 _openai_api_key = os.environ.get("OPENAI_API_KEY")
 if not _openai_api_key:


### PR DESCRIPTION
## Summary
- allow configuring CORS origins for the FastAPI backend so the admin UI can reach it from the browser
- document the new ALLOWED_ORIGINS variable and update the sample environment file

## Testing
- python3 -m compileall backend/server.py

------
https://chatgpt.com/codex/tasks/task_e_68e5cb6587948322a6b8d99fb08ec251