### PR TITLE
Expose weather agent through ChatKit server

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,33 @@ Les scripts utilisent `uv` et `npm` en ciblant les sous-dossiers, évitant ainsi
 
 The `/api/chatkit/session` route makes an HTTP request to `https://api.openai.com/v1/chatkit/sessions` using `httpx`, mirroring the official starter app. Si un utilisateur est authentifié, son identifiant interne est réutilisé pour générer la session. A `requirements.txt` remains available for `pip install -r requirements.txt`.
 
+### Exemple : déclarer un tool Python
+
+Le fichier `backend/weather_agent.py` fournit une démonstration minimale de l'utilisation d'un `Agent` ChatKit et d'un outil Python décoré avec `@function_tool`. L'agent possède un outil `get_weather` qui renvoie une météo fictive en fonction de la ville demandée, puis `Runner.run_sync` est utilisé pour traiter plusieurs questions successives.
+
+Pour lancer l'exemple, exécutez depuis le dossier `backend/` :
+
+```bash
+uv run python weather_agent.py
+```
+
+Si `uv` n'est pas disponible, vous pouvez remplacer la commande par `python3 weather_agent.py` dans le même répertoire.
+
+### Exposer l'agent météo via ChatKit
+
+Le module `backend/weather_chatkit_server.py` fournit une implémentation FastAPI du protocole ChatKit en s'appuyant sur un magasin en mémoire et le même agent météo. Le point d'entrée `POST /chatkit/weather` restitue les événements SSE attendus par le widget ChatKit.
+
+1. Depuis `backend/`, démarrez le serveur :
+
+   ```bash
+   uv run uvicorn weather_chatkit_server:app --reload
+   ```
+
+   Sans `uv`, utilisez `python3 -m uvicorn weather_chatkit_server:app --reload` dans ce dossier.
+2. Côté client, configurez `apiURL` sur `http://localhost:8000/chatkit/weather` (ou l'URL exposée par votre reverse proxy) pour consommer l'agent météo directement depuis ChatKit.
+
+Le stockage étant purement en mémoire, chaque redémarrage du serveur réinitialise les fils de discussion. Adaptez l'implémentation du `Store` si vous souhaitez connecter une base de données persistante.
+
 ## Frontend (`frontend/`)
 
 - Install JavaScript dependencies from within `frontend/`: `npm install` (ou `npm run frontend:install` à la racine)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
     "fastapi>=0.110.0",
     "openai>=1.30.0",
+    "openai-chatkit>=0.0.2",
     "uvicorn[standard]>=0.29.0",
     "python-dotenv>=1.0.1",
     "httpx>=0.27.0",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi>=0.110.0
 openai>=1.30.0
+openai-chatkit>=0.0.2
 uvicorn[standard]>=0.29.0
 python-dotenv>=1.0.1
 httpx>=0.27.0

--- a/backend/weather_agent.py
+++ b/backend/weather_agent.py
@@ -1,0 +1,44 @@
+"""Démo minimale d'un agent ChatKit avec un outil météo."""
+
+from __future__ import annotations
+
+from agents import Agent, Runner, function_tool
+
+__all__ = ["agent", "create_agent", "get_weather"]
+
+
+@function_tool
+def get_weather(city: str) -> str:
+    """Retourne la météo pour une ville donnée."""
+    base = {
+        "Paris": "Ensoleillé, 24°C",
+        "Lyon": "Pluvieux, 18°C",
+        "Marseille": "Vent fort, 27°C",
+    }
+    return base.get(city, f"Je n'ai pas trouvé la météo pour {city}.")
+
+
+def create_agent() -> Agent:
+    """Construit un agent météo prêt à être utilisé."""
+
+    return Agent(
+        name="Assistant météo",
+        model="gpt-4.1-mini",
+        instructions=(
+            "Donne la météo actuelle en utilisant l'outil get_weather si besoin."
+        ),
+        tools=[get_weather],
+    )
+
+
+agent = create_agent()
+
+
+if __name__ == "__main__":
+    for question in (
+        "Quel temps fait-il à Paris ?",
+        "Et à Lyon ?",
+        "Et à Londres ?",
+    ):
+        result = Runner.run_sync(agent, question)
+        print(result.final_output)

--- a/backend/weather_chatkit_server.py
+++ b/backend/weather_chatkit_server.py
@@ -1,0 +1,247 @@
+"""Expose l'agent météo via une implémentation minimale du protocole ChatKit."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import StreamingResponse
+
+from agents import Runner
+from chatkit.agents import AgentContext, simple_to_agent_input, stream_agent_response
+from chatkit.server import ChatKitServer, NonStreamingResult, StreamingResult
+from chatkit.store import NotFoundError, Store
+from chatkit.types import Attachment, Page, ThreadItem, ThreadMetadata, ThreadStreamEvent, UserMessageItem
+
+from weather_agent import create_agent
+
+
+def _deep_copy_item(item: ThreadItem) -> ThreadItem:
+    """Retourne une copie profonde du ThreadItem pour éviter les mutations."""
+
+    copy_method = getattr(item, "model_copy", None)
+    if callable(copy_method):  # pydantic >= 2
+        return copy_method(deep=True)
+    return item
+
+
+def _deep_copy_attachment(attachment: Attachment) -> Attachment:
+    copy_method = getattr(attachment, "model_copy", None)
+    if callable(copy_method):
+        return copy_method(deep=True)
+    return attachment
+
+
+class InMemoryStore(Store[dict[str, Any]]):
+    """Dépôt en mémoire répondant à l'interface `Store` de ChatKit."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._threads: dict[str, ThreadMetadata] = {}
+        self._thread_items: dict[str, list[ThreadItem]] = {}
+        self._attachments: dict[str, Attachment] = {}
+        self._lock = asyncio.Lock()
+
+    async def load_thread(self, thread_id: str, context: dict[str, Any]) -> ThreadMetadata:
+        async with self._lock:
+            metadata = self._threads.get(thread_id)
+            if metadata is None:
+                raise NotFoundError(f"Thread {thread_id} introuvable")
+            return metadata.model_copy(deep=True)
+
+    async def save_thread(self, thread: ThreadMetadata, context: dict[str, Any]) -> None:
+        async with self._lock:
+            metadata = thread.model_copy(deep=True)
+            self._threads[metadata.id] = metadata
+            self._thread_items.setdefault(metadata.id, [])
+
+    async def load_thread_items(
+        self,
+        thread_id: str,
+        after: str | None,
+        limit: int,
+        order: str,
+        context: dict[str, Any],
+    ) -> Page[ThreadItem]:
+        async with self._lock:
+            items = list(self._thread_items.get(thread_id, []))
+            items.sort(key=lambda item: item.created_at)
+            if order == "desc":
+                items.reverse()
+
+            start = 0
+            if after:
+                for index, candidate in enumerate(items):
+                    if candidate.id == after:
+                        start = index + 1
+                        break
+                else:
+                    raise NotFoundError(f"Élément {after} introuvable pour le thread {thread_id}")
+
+            slice_ = items[start : start + limit]
+            has_more = start + limit < len(items)
+            after_token = slice_[-1].id if has_more and slice_ else None
+            return Page[ThreadItem](
+                data=[_deep_copy_item(item) for item in slice_],
+                has_more=has_more,
+                after=after_token,
+            )
+
+    async def save_attachment(self, attachment: Attachment, context: dict[str, Any]) -> None:
+        async with self._lock:
+            self._attachments[attachment.id] = _deep_copy_attachment(attachment)
+
+    async def load_attachment(self, attachment_id: str, context: dict[str, Any]) -> Attachment:
+        async with self._lock:
+            attachment = self._attachments.get(attachment_id)
+            if attachment is None:
+                raise NotFoundError(f"Pièce jointe {attachment_id} introuvable")
+            return _deep_copy_attachment(attachment)
+
+    async def delete_attachment(self, attachment_id: str, context: dict[str, Any]) -> None:
+        async with self._lock:
+            self._attachments.pop(attachment_id, None)
+
+    async def load_threads(
+        self,
+        limit: int,
+        after: str | None,
+        order: str,
+        context: dict[str, Any],
+    ) -> Page[ThreadMetadata]:
+        async with self._lock:
+            threads = list(self._threads.values())
+            threads.sort(key=lambda metadata: metadata.created_at)
+            if order == "desc":
+                threads.reverse()
+
+            start = 0
+            if after:
+                for index, metadata in enumerate(threads):
+                    if metadata.id == after:
+                        start = index + 1
+                        break
+                else:
+                    raise NotFoundError(f"Thread {after} introuvable")
+
+            slice_ = threads[start : start + limit]
+            has_more = start + limit < len(threads)
+            after_token = slice_[-1].id if has_more and slice_ else None
+            return Page[ThreadMetadata](
+                data=[metadata.model_copy(deep=True) for metadata in slice_],
+                has_more=has_more,
+                after=after_token,
+            )
+
+    async def add_thread_item(
+        self, thread_id: str, item: ThreadItem, context: dict[str, Any]
+    ) -> None:
+        async with self._lock:
+            if thread_id not in self._threads:
+                raise NotFoundError(f"Thread {thread_id} introuvable")
+            items = self._thread_items.setdefault(thread_id, [])
+            items.append(_deep_copy_item(item))
+            items.sort(key=lambda candidate: candidate.created_at)
+
+    async def save_item(
+        self, thread_id: str, item: ThreadItem, context: dict[str, Any]
+    ) -> None:
+        async with self._lock:
+            items = self._thread_items.get(thread_id)
+            if items is None:
+                raise NotFoundError(f"Thread {thread_id} introuvable")
+            for index, candidate in enumerate(items):
+                if candidate.id == item.id:
+                    items[index] = _deep_copy_item(item)
+                    break
+            else:
+                raise NotFoundError(f"Élément {item.id} introuvable dans le thread {thread_id}")
+
+    async def load_item(
+        self, thread_id: str, item_id: str, context: dict[str, Any]
+    ) -> ThreadItem:
+        async with self._lock:
+            items = self._thread_items.get(thread_id)
+            if items is None:
+                raise NotFoundError(f"Thread {thread_id} introuvable")
+            for candidate in items:
+                if candidate.id == item_id:
+                    return _deep_copy_item(candidate)
+            raise NotFoundError(f"Élément {item_id} introuvable dans le thread {thread_id}")
+
+    async def delete_thread(self, thread_id: str, context: dict[str, Any]) -> None:
+        async with self._lock:
+            self._threads.pop(thread_id, None)
+            self._thread_items.pop(thread_id, None)
+
+    async def delete_thread_item(
+        self, thread_id: str, item_id: str, context: dict[str, Any]
+    ) -> None:
+        async with self._lock:
+            items = self._thread_items.get(thread_id)
+            if not items:
+                raise NotFoundError(f"Thread {thread_id} introuvable")
+            self._thread_items[thread_id] = [
+                candidate for candidate in items if candidate.id != item_id
+            ]
+
+
+class WeatherChatKitServer(ChatKitServer[dict[str, Any]]):
+    """Serveur ChatKit pilotant l'agent météo."""
+
+    def __init__(self) -> None:
+        super().__init__(store=InMemoryStore())
+        self._agent = create_agent()
+
+    async def respond(
+        self,
+        thread: ThreadMetadata,
+        input_user_message: UserMessageItem | None,
+        context: dict[str, Any],
+    ) -> AsyncIterator[ThreadStreamEvent]:
+        agent_context = AgentContext(
+            thread=thread,
+            store=self.store,
+            request_context=context,
+            previous_response_id=None,
+        )
+
+        history = await self.store.load_thread_items(
+            thread.id,
+            after=None,
+            limit=100,
+            order="asc",
+            context=context,
+        )
+
+        agent_input = simple_to_agent_input(history.data)
+        result = Runner.run_streamed(
+            self._agent,
+            agent_input,
+            context=agent_context,
+        )
+
+        async for event in stream_agent_response(agent_context, result):
+            yield event
+
+
+app = FastAPI(title="ChatKit météo", version="0.1.0")
+server = WeatherChatKitServer()
+
+
+@app.post("/chatkit/weather")
+async def chatkit_weather_endpoint(request: Request) -> Response | StreamingResponse:
+    """Point d'entrée compatible ChatKit pour l'agent météo."""
+
+    body = await request.body()
+    result = await server.process(body, context={})
+
+    if isinstance(result, StreamingResult):
+        return StreamingResponse(result, media_type="text/event-stream")
+    if isinstance(result, NonStreamingResult):
+        return Response(content=result.json, media_type="application/json")
+
+    raise RuntimeError("Type de réponse ChatKit inattendu")
+


### PR DESCRIPTION
## Summary
- add a FastAPI-based ChatKit server exposing the weather agent at /chatkit/weather with an in-memory store
- export a factory for the weather agent and document how to run the new ChatKit endpoint
- declare openai-chatkit as a backend dependency for reproducible installs

## Testing
- python -m compileall backend/weather_agent.py backend/weather_chatkit_server.py

------
https://chatgpt.com/codex/tasks/task_e_68e654e90b4c832283d9bfc9758e3d1b