### PR TITLE
Corrige l'hôte HMR mal formaté dans la configuration Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Le composant React `MyChat` enregistre un gestionnaire `onClientTool` pour l'out
 - The project depends on React 19, matching the official starter app requirements for `@openai/chatkit-react`
 - `vite.config.ts` proxies `/api/chatkit/session` requests to the FastAPI backend running on port 8000
 - `VITE_BACKEND_URL` définit l'URL cible du backend pour l'ensemble des appels `/api/*`
+- `VITE_HMR_HOST` doit se limiter à un nom d'hôte (avec éventuellement un port). Une faute de frappe du type `https//mon-domaine`
+  conduit le navigateur à tenter de joindre `https://https//mon-domaine`, ce qui se traduit par une erreur DNS (`net::ERR_NAME_NOT_RESOLVED`).
+  Le fichier `vite.config.ts` nettoie désormais automatiquement ce genre d'entrée, mais il est préférable de corriger la valeur dans
+  votre `.env` pour éviter toute ambiguïté.
 - Les requêtes de connexion basculent automatiquement sur `/api/auth/login` (même origine) puis, en cas d'échec réseau, réessaient avec `VITE_BACKEND_URL` ; cela évite les erreurs « Failed to fetch » lorsque le navigateur n'a pas de résolution DNS pour `backend` en environnement Docker.
 - `VITE_ALLOWED_HOSTS` permet d'ajouter une liste d'hôtes supplémentaires autorisés par le serveur Vite (séparés par des virgules)
 - `index.html` already loads the ChatKit CDN script: `<script src="https://cdn.platform.openai.com/deployments/chatkit/chatkit.js" async></script>`

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,16 +6,38 @@ const parsePort = (value: string | undefined, fallback: number) => {
   return Number.isFinite(parsed) ? parsed : fallback;
 };
 
+const sanitizeHost = (value: string | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  let sanitized = value.trim();
+  if (!sanitized) {
+    return undefined;
+  }
+
+  sanitized = sanitized
+    // tolère les schémas mal renseignés type « https//mon-domaine »
+    .replace(/^(https?|wss?):?\/\//i, "")
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "");
+
+  return sanitized || undefined;
+};
+
+const withFallback = (value: string | undefined, fallback: string) =>
+  sanitizeHost(value) ?? fallback;
+
 const serverPort = parsePort(process.env.VITE_PORT, 5183);
 const hmrClientPort = parsePort(process.env.VITE_HMR_CLIENT_PORT, 443);
-const hmrHost = process.env.VITE_HMR_HOST ?? "test.ve2fpd.com";
+const hmrHost = withFallback(process.env.VITE_HMR_HOST, "test.ve2fpd.com");
 const hmrProtocol = process.env.VITE_HMR_PROTOCOL ?? "wss";
 const backendTarget =
   process.env.VITE_BACKEND_URL ?? "http://127.0.0.1:8000";
 const defaultAllowedHosts = ["chatkit.ve2fpd.com"];
 const envAllowedHosts = process.env.VITE_ALLOWED_HOSTS?.split(",")
-  .map((host) => host.trim())
-  .filter((host) => host.length > 0);
+  .map((host) => sanitizeHost(host))
+  .filter((host): host is string => Boolean(host));
 const allowedHosts = envAllowedHosts?.length
   ? Array.from(new Set([...envAllowedHosts, ...defaultAllowedHosts]))
   : defaultAllowedHosts;


### PR DESCRIPTION
## Résumé
- nettoie les valeurs HMR contenant un schéma pour éviter les hôtes du type `https//domain`
- documente dans le README la cause de l'erreur `net::ERR_NAME_NOT_RESOLVED`

## Tests
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68e66c36e0c88322b685678114ce0d37