### PR TITLE
Set Next.js app port to 5183

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 5183",
     "build": "next build",
-    "start": "next start",
+    "start": "next start --port 5183",
     "lint": "eslint"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- configure the Next.js dev and production scripts to run on port 5183 by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6742ab98c8322b3cf249fe1fc3413