### PR TITLE
Add OpenAI domain verification support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 # Clé API OpenAI disposant de l'accès ChatKit (obligatoire)
 OPENAI_API_KEY="sk-your-openai-api-key"
 
+# Jeton de vérification de domaine (optionnel, fourni dans le panneau Domain Allowlist)
+# OPENAI_DOMAIN_VERIFICATION_TOKEN="your-domain-token"
+
 # Identifiant du workflow ChatKit à utiliser (obligatoire)
 CHATKIT_WORKFLOW_ID="workflow-your-workflow-id"
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Update `.env.local` with the variables that match your setup.
 - `OPENAI_API_KEY` — API key created **within the same org & project as your Agent Builder**
 - `NEXT_PUBLIC_CHATKIT_WORKFLOW_ID` — the workflow you created in [Agent Builder](https://platform.openai.com/agent-builder)
 - (optional) `CHATKIT_API_BASE` - customizable base URL for the ChatKit API endpoint
+- (optional) `OPENAI_DOMAIN_VERIFICATION_TOKEN` — token provided in the [domain allowlist settings](https://platform.openai.com/settings/organization/security/domain-allowlist) so the app can expose the verification meta tag and `/.well-known/openai-domain-verification` file automatically
 
 ### 4. Run the app
 

--- a/app/.well-known/openai-domain-verification/route.ts
+++ b/app/.well-known/openai-domain-verification/route.ts
@@ -1,0 +1,24 @@
+const token =
+  process.env.OPENAI_DOMAIN_VERIFICATION_TOKEN?.trim() ??
+  process.env.NEXT_PUBLIC_OPENAI_DOMAIN_VERIFICATION_TOKEN?.trim() ??
+  "";
+
+export function GET(): Response {
+  if (!token) {
+    return new Response("Verification token is not configured", {
+      status: 404,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
+  return new Response(`openai-domain-verification=${token}`.trim(), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=300, must-revalidate",
+    },
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,9 +2,21 @@ import Script from "next/script";
 import type { Metadata } from "next";
 import "./globals.css";
 
+const openAIDomainVerificationToken =
+  process.env.OPENAI_DOMAIN_VERIFICATION_TOKEN?.trim() ??
+  process.env.NEXT_PUBLIC_OPENAI_DOMAIN_VERIFICATION_TOKEN?.trim() ??
+  "";
+
 export const metadata: Metadata = {
   title: "AgentKit demo",
   description: "Demo of ChatKit with hosted workflow",
+  ...(openAIDomainVerificationToken
+    ? {
+        other: {
+          "openai-domain-verification": openAIDomainVerificationToken,
+        },
+      }
+    : {}),
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- allow configuring an OpenAI domain verification token that is surfaced in metadata
- expose a /.well-known/openai-domain-verification endpoint that serves the token for allowlist checks
- document the new environment variable in the README and example env file

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e676ac46088322ab92b4e6d3e0f7ba