### PR TITLE
Update ChatKit script host

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,11 +24,14 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const chatKitScriptSrc =
+    process.env.NEXT_PUBLIC_CHATKIT_SCRIPT_URL?.trim() ??
+    "https://chatkit.ve2fpd.com/deployments/chatkit/chatkit.js";
   return (
     <html lang="en">
       <head>
         <Script
-          src="https://cdn.platform.openai.com/deployments/chatkit/chatkit.js"
+          src={chatKitScriptSrc}
           strategy="beforeInteractive"
         />
       </head>


### PR DESCRIPTION
## Summary
- load the ChatKit web component script from the new chatkit.ve2fpd.com domain by default
- allow overriding the script URL via NEXT_PUBLIC_CHATKIT_SCRIPT_URL for flexibility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e67ba135f08322a775015f17c1afb6