### PR TITLE
Sanitize weather tool payload for ChatKit

### DIFF
--- a/lib/weather.ts
+++ b/lib/weather.ts
@@ -4,9 +4,9 @@ type ResolvedCoordinates = {
   latitude: number;
   longitude: number;
   name: string;
-  region?: string | null;
-  country?: string | null;
-  timezone?: string | null;
+  region: string | null;
+  country: string | null;
+  timezone: string | null;
 };
 
 type WeatherApiResponse = {
@@ -21,17 +21,17 @@ type WeatherApiResponse = {
   timezone?: string;
 };
 
-type WeatherResult = {
+export type WeatherResult = {
   location: {
     name: string;
-    region?: string | null;
-    country?: string | null;
+    region: string | null;
+    country: string | null;
     latitude: number;
     longitude: number;
-    timezone?: string | null;
+    timezone: string | null;
   };
   current: {
-    time?: string;
+    time: string | null;
     temperatureCelsius: number | null;
     temperatureFahrenheit: number | null;
     apparentTemperatureCelsius: number | null;
@@ -113,7 +113,7 @@ export async function getWeather(
       timezone: coordinates.timezone ?? data?.timezone ?? null,
     },
     current: {
-      time: typeof current?.time === "string" ? current?.time : undefined,
+      time: typeof current?.time === "string" ? current?.time : null,
       temperatureCelsius: temperatureC,
       temperatureFahrenheit: convertToFahrenheit(temperatureC),
       apparentTemperatureCelsius: apparentC,
@@ -137,7 +137,14 @@ async function resolveCoordinates(
 
   if (typeof latitude === "number" && typeof longitude === "number") {
     const name = inferNameFromParams(params) ?? "Provided coordinates";
-    return { latitude, longitude, name };
+    return {
+      latitude,
+      longitude,
+      name,
+      region: null,
+      country: null,
+      timezone: null,
+    };
   }
 
   const location = inferLocationName(params);


### PR DESCRIPTION
## Summary
- ensure the weather tool response always uses primitive values or null so it remains JSON serializable for ChatKit
- populate missing coordinate metadata with explicit null defaults when the workflow supplies raw latitude and longitude values

## Testing
- npm run lint *(fails: missing @eslint/eslintrc dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6854ea14083228bcf8a366558331e