### PR TITLE
Fix ChatKit client tool output CORS by proxying conversation requests

### DIFF
--- a/app/api/chatkit/conversation/route.ts
+++ b/app/api/chatkit/conversation/route.ts
@@ -1,0 +1,88 @@
+const DEFAULT_CHATKIT_BASE = "https://api.openai.com";
+
+export const runtime = "edge";
+
+export async function POST(request: Request): Promise<Response> {
+  if (request.method !== "POST") {
+    return methodNotAllowed();
+  }
+
+  try {
+    const apiBase = process.env.CHATKIT_API_BASE ?? DEFAULT_CHATKIT_BASE;
+    const upstreamUrl = `${apiBase}/v1/chatkit/conversation`;
+
+    const bodyText = await request.text();
+    const upstreamHeaders = new Headers();
+
+    request.headers.forEach((value, key) => {
+      if (key.toLowerCase() === "host" || key.toLowerCase() === "content-length") {
+        return;
+      }
+      upstreamHeaders.set(key, value);
+    });
+
+    if (!upstreamHeaders.has("authorization")) {
+      const apiKey = process.env.OPENAI_API_KEY;
+      if (!apiKey) {
+        return buildJsonResponse(
+          { error: "Missing credentials for ChatKit conversation forwarding." },
+          500
+        );
+      }
+      upstreamHeaders.set("Authorization", `Bearer ${apiKey}`);
+    }
+
+    if (!upstreamHeaders.has("openai-beta")) {
+      upstreamHeaders.set("OpenAI-Beta", "chatkit_beta=v1");
+    }
+
+    if (!upstreamHeaders.has("content-type") && bodyText) {
+      upstreamHeaders.set("Content-Type", "application/json");
+    }
+
+    const upstreamResponse = await fetch(upstreamUrl, {
+      method: "POST",
+      headers: upstreamHeaders,
+      body: bodyText || undefined,
+    });
+
+    const responseHeaders = filterResponseHeaders(upstreamResponse.headers);
+    const responseBody = await upstreamResponse.text();
+
+    return new Response(responseBody, {
+      status: upstreamResponse.status,
+      headers: responseHeaders,
+    });
+  } catch (error) {
+    console.error("[chatkit-conversation] forwarding failed", error);
+    return buildJsonResponse({ error: "Failed to forward ChatKit conversation request." }, 500);
+  }
+}
+
+export async function GET(): Promise<Response> {
+  return methodNotAllowed();
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return methodNotAllowed();
+}
+
+function filterResponseHeaders(headers: Headers): Headers {
+  const filtered = new Headers();
+  const contentType = headers.get("content-type");
+  if (contentType) {
+    filtered.set("Content-Type", contentType);
+  }
+  return filtered;
+}
+
+function buildJsonResponse(payload: unknown, status: number): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function methodNotAllowed(): Response {
+  return buildJsonResponse({ error: "Method Not Allowed" }, 405);
+}

--- a/components/ChatKitPanel.tsx
+++ b/components/ChatKitPanel.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { ChatKit, useChatKit } from "@openai/chatkit-react";
 import {
   STARTER_PROMPTS,
@@ -73,7 +79,7 @@ export function ChatKitPanel({
     };
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const removeProxy = installChatKitConversationProxy();
     return () => {
       removeProxy();

--- a/components/ChatKitPanel.tsx
+++ b/components/ChatKitPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/config";
 import { ErrorOverlay } from "./ErrorOverlay";
 import { getWeather } from "@/lib/weather";
+import { installChatKitConversationProxy } from "@/lib/chatkitConversationProxy";
 import type { ColorScheme } from "@/hooks/useColorScheme";
 
 export type FactAction = {
@@ -69,6 +70,13 @@ export function ChatKitPanel({
   useEffect(() => {
     return () => {
       isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const removeProxy = installChatKitConversationProxy();
+    return () => {
+      removeProxy();
     };
   }, []);
 

--- a/lib/chatkitConversationProxy.ts
+++ b/lib/chatkitConversationProxy.ts
@@ -1,0 +1,127 @@
+const HOSTED_CONVERSATION_URL = "https://api.openai.com/v1/chatkit/conversation";
+const PROXY_ENDPOINT = "/api/chatkit/conversation";
+
+const PROXY_FLAG = "__chatkitConversationProxyInstalled";
+
+type ExtendedWindow = Window & {
+  [PROXY_FLAG]?: boolean;
+};
+
+const isBrowser = typeof window !== "undefined";
+
+export function installChatKitConversationProxy(): () => void {
+  if (!isBrowser) {
+    return () => {};
+  }
+
+  const win = window as ExtendedWindow;
+  if (win[PROXY_FLAG]) {
+    return () => {};
+  }
+
+  const originalFetch = window.fetch.bind(window);
+
+  const proxiedFetch: typeof window.fetch = (
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ) => {
+    let request: Request;
+    try {
+      request =
+        input instanceof Request ? input : new Request(input, init);
+    } catch (error) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(
+          "[ChatKitPanel] Unable to inspect fetch request, falling back to original fetch",
+          error
+        );
+      }
+      return originalFetch(input as RequestInfo | URL, init);
+    }
+
+    if (shouldProxyConversationRequest(request.url)) {
+      return proxyConversationRequest(request, originalFetch);
+    }
+
+    return originalFetch(input as RequestInfo | URL, init);
+  };
+
+  window.fetch = proxiedFetch;
+  win[PROXY_FLAG] = true;
+
+  return () => {
+    if (!isBrowser) {
+      return;
+    }
+
+    const currentWindow = window as ExtendedWindow;
+    if (currentWindow[PROXY_FLAG]) {
+      window.fetch = originalFetch;
+      currentWindow[PROXY_FLAG] = false;
+    }
+  };
+}
+
+function shouldProxyConversationRequest(url: string): boolean {
+  if (!url) {
+    return false;
+  }
+
+  try {
+    const resolved = new URL(url, window.location.origin);
+    const target = resolved.origin + resolved.pathname;
+    const hosted = new URL(HOSTED_CONVERSATION_URL);
+    const hostedTarget = hosted.origin + hosted.pathname;
+    return target === hostedTarget;
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(
+        "[ChatKitPanel] Failed to parse request URL when evaluating proxy",
+        { url, error }
+      );
+    }
+    return false;
+  }
+}
+
+async function proxyConversationRequest(
+  request: Request,
+  originalFetch: typeof fetch
+): Promise<Response> {
+  const cloned = request.clone();
+
+  const headers = new Headers(cloned.headers);
+  headers.delete("host");
+  headers.delete("content-length");
+
+  if (!headers.has("content-type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  if (!headers.has("openai-beta")) {
+    headers.set("OpenAI-Beta", "chatkit_beta=v1");
+  }
+
+  const init: RequestInit = {
+    method: cloned.method,
+    headers,
+    cache: cloned.cache,
+    credentials: cloned.credentials,
+    integrity: cloned.integrity,
+    keepalive: cloned.keepalive,
+    redirect: cloned.redirect,
+    referrer: cloned.referrer === "about:client" ? undefined : cloned.referrer,
+    referrerPolicy: cloned.referrerPolicy,
+    signal: cloned.signal,
+  };
+
+  if (cloned.method !== "GET" && cloned.method !== "HEAD") {
+    const bodyText = await cloned.text();
+    init.body = bodyText;
+  }
+
+  if (process.env.NODE_ENV !== "production") {
+    console.info("[ChatKitPanel] Proxying conversation request to backend");
+  }
+
+  return originalFetch(PROXY_ENDPOINT, init);
+}


### PR DESCRIPTION
## Summary
- add an edge API route that forwards ChatKit conversation requests through the Next.js backend so tool output posts bypass CORS restrictions
- install a client-side fetch proxy that reroutes the widget's threads.add_client_tool_output calls to the new backend endpoint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e68a9f3fd88322860bf31fd37c46ea